### PR TITLE
Triggering `onBotStartedSpeaking` and `onBotStoppedSpeaking` based on the RTVI events that we receive from Pipecat.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,10 @@
-# 0.3.3 - 2025-03-20
+# 0.3.5 - 2025-04-02
+
+### Added
+
+- Triggering `onBotStartedSpeaking` and `onBotStoppedSpeaking` based on the RTVI events that we receive from Pipecat.
+
+# 0.3.4 - 2025-03-20
 
 ### Added
 

--- a/Sources/PipecatClientIOS/RTVIClient.swift
+++ b/Sources/PipecatClientIOS/RTVIClient.swift
@@ -63,6 +63,10 @@ open class RTVIClient {
             self.delegate?.onUserStartedSpeaking()
         case RTVIMessageInbound.MessageType.USER_STOPPED_SPEAKING:
             self.delegate?.onUserStoppedSpeaking()
+        case RTVIMessageInbound.MessageType.BOT_STARTED_SPEAKING:
+            self.delegate?.onBotStartedSpeaking()
+        case RTVIMessageInbound.MessageType.BOT_STOPPED_SPEAKING:
+            self.delegate?.onBotStoppedSpeaking()
         case RTVIMessageInbound.MessageType.ACTION_RESPONSE:
             _ = self.messageDispatcher.resolve(message: voiceMessage)
         case RTVIMessageInbound.MessageType.DESCRIBE_ACTION_RESPONSE:

--- a/Sources/PipecatClientIOS/RTVIClientDelegate.swift
+++ b/Sources/PipecatClientIOS/RTVIClientDelegate.swift
@@ -54,10 +54,18 @@ public protocol RTVIClientDelegate: AnyObject {
     func onRemoteAudioLevel( level: Float, participant: Participant)
 
     /// Invoked when the bot starts talking.
+    @available(*, deprecated, message: "Use onBotStartedSpeaking() instead")
     func onBotStartedSpeaking( participant: Participant)
+    
+    /// Invoked when the bot starts talking.
+    func onBotStartedSpeaking()
 
     /// Invoked when the bot stops talking.
+    @available(*, deprecated, message: "Use onBotStoppedSpeaking() instead")
     func onBotStoppedSpeaking( participant: Participant)
+    
+    /// Invoked when the bot stops talking.
+    func onBotStoppedSpeaking()
 
     /// Invoked when the local user starts talking.
     func onUserStartedSpeaking()
@@ -123,8 +131,12 @@ public extension RTVIClientDelegate {
     func onMicUpdated( mic: MediaDeviceInfo?) {}
     func onUserAudioLevel( level: Float) {}
     func onRemoteAudioLevel( level: Float, participant: Participant) {}
+    @available(*, deprecated, message: "Use onBotStartedSpeaking() instead")
     func onBotStartedSpeaking( participant: Participant) {}
+    func onBotStartedSpeaking() {}
+    @available(*, deprecated, message: "Use onBotStoppedSpeaking() instead")
     func onBotStoppedSpeaking( participant: Participant) {}
+    func onBotStoppedSpeaking() {}
     func onUserStartedSpeaking() {}
     func onUserStoppedSpeaking() {}
     func onMetrics( data: PipecatMetrics) {}


### PR DESCRIPTION
Triggering `onBotStartedSpeaking` and `onBotStoppedSpeaking` based on the RTVI events that we receive from Pipecat.