### PR TITLE
feat: Add Bot LLM Search Response support 

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,3 @@
 /.swiftpm/xcode/xcuserdata
 tmpDocs/
+.build/

--- a/Sources/PipecatClientIOS/RTVIClient.swift
+++ b/Sources/PipecatClientIOS/RTVIClient.swift
@@ -58,6 +58,10 @@ open class RTVIClient {
             if let storedData = try? JSONDecoder().decode(Value.self, from: Data(voiceMessage.data!.utf8)) {
                 self.delegate?.onServerMessage(data: storedData)
             }
+        case RTVIMessageInbound.MessageType.BOT_LLM_SEARCH_RESPONSE:
+            if let searchResponseData = try? JSONDecoder().decode(BotLLMSearchResponseData.self, from: Data(voiceMessage.data!.utf8)) {
+                self.delegate?.onBotLlmSearchResponse(data: searchResponseData)
+            }
         case RTVIMessageInbound.MessageType.PIPECAT_METRICS:
             guard let metrics = voiceMessage.metrics else {
                 return

--- a/Sources/PipecatClientIOS/RTVIClientDelegate.swift
+++ b/Sources/PipecatClientIOS/RTVIClientDelegate.swift
@@ -114,6 +114,9 @@ public protocol RTVIClientDelegate: AnyObject {
     
     /// Invoked when we receive a server message from the bot.
     func onServerMessage(data: Value)
+    
+    /// Invoked when bot LLM search response data is received.
+    func onBotLlmSearchResponse(data: BotLLMSearchResponseData)
 }
 
 public extension RTVIClientDelegate {
@@ -156,4 +159,5 @@ public extension RTVIClientDelegate {
     func onBotTTSStopped() {}
     func onStorageItemStored(data: StorageItemStoredData) {}
     func onServerMessage(data: Value) {}
+    func onBotLlmSearchResponse(data: BotLLMSearchResponseData) {}
 }

--- a/Sources/PipecatClientIOS/transport/RTVIMessageInbound.swift
+++ b/Sources/PipecatClientIOS/transport/RTVIMessageInbound.swift
@@ -74,6 +74,9 @@ public struct RTVIMessageInbound: Codable {
         
         /// Server message
         public static let SERVER_MESSAGE = "server-message"
+        
+        /// Bot LLM search response data
+        public static let BOT_LLM_SEARCH_RESPONSE = "bot-llm-search-response"
     }
 
     public init(type: String?, data: String?) {

--- a/Sources/PipecatClientIOS/types/BotLLMSearchResponse.swift
+++ b/Sources/PipecatClientIOS/types/BotLLMSearchResponse.swift
@@ -1,0 +1,100 @@
+import Foundation
+
+/// Search entry point from bot LLM search response
+public struct SearchEntryPoint: Codable {
+    public let renderedContent: String?
+    
+    enum CodingKeys: String, CodingKey {
+        case renderedContent = "rendered_content"
+    }
+    
+    public init(renderedContent: String?) {
+        self.renderedContent = renderedContent
+    }
+}
+
+/// Web source information from bot LLM search response
+public struct WebSource: Codable {
+    public let uri: String?
+    public let title: String?
+    
+    public init(uri: String?, title: String?) {
+        self.uri = uri
+        self.title = title
+    }
+}
+
+/// Grounding chunk information
+public struct GroundingChunk: Codable {
+    public let web: WebSource?
+    
+    public init(web: WebSource?) {
+        self.web = web
+    }
+}
+
+/// Grounding segment information
+public struct GroundingSegment: Codable {
+    public let partIndex: Int?
+    public let startIndex: Int?
+    public let endIndex: Int?
+    public let text: String?
+    
+    enum CodingKeys: String, CodingKey {
+        case partIndex = "part_index"
+        case startIndex = "start_index"
+        case endIndex = "end_index"
+        case text
+    }
+    
+    public init(partIndex: Int?, startIndex: Int?, endIndex: Int?, text: String?) {
+        self.partIndex = partIndex
+        self.startIndex = startIndex
+        self.endIndex = endIndex
+        self.text = text
+    }
+}
+
+/// Grounding support information
+public struct GroundingSupport: Codable {
+    public let segment: GroundingSegment?
+    public let groundingChunkIndices: [Int]?
+    public let confidenceScores: [Double]?
+    
+    enum CodingKeys: String, CodingKey {
+        case segment
+        case groundingChunkIndices = "grounding_chunk_indices"
+        case confidenceScores = "confidence_scores"
+    }
+    
+    public init(segment: GroundingSegment?, groundingChunkIndices: [Int]?, confidenceScores: [Double]?) {
+        self.segment = segment
+        self.groundingChunkIndices = groundingChunkIndices
+        self.confidenceScores = confidenceScores
+    }
+}
+
+/// Bot LLM search response data structure received from the backend
+public struct BotLLMSearchResponseData: Codable {
+    public let searchEntryPoint: SearchEntryPoint?
+    public let groundingChunks: [GroundingChunk]?
+    public let groundingSupports: [GroundingSupport]?
+    public let webSearchQueries: [String]?
+    
+    enum CodingKeys: String, CodingKey {
+        case searchEntryPoint = "search_entry_point"
+        case groundingChunks = "grounding_chunks"
+        case groundingSupports = "grounding_supports"
+        case webSearchQueries = "web_search_queries"
+    }
+    
+    public init(searchEntryPoint: SearchEntryPoint?, groundingChunks: [GroundingChunk]?, groundingSupports: [GroundingSupport]?, webSearchQueries: [String]?) {
+        self.searchEntryPoint = searchEntryPoint
+        self.groundingChunks = groundingChunks
+        self.groundingSupports = groundingSupports
+        self.webSearchQueries = webSearchQueries
+    }
+}
+
+// Legacy alias for backward compatibility
+public typealias GroundingMetadata = BotLLMSearchResponseData 


### PR DESCRIPTION
- Add BotLLMSearchResponseData and related types (SearchEntryPoint, WebSource, GroundingChunk, GroundingSegment, GroundingSupport)
- Add BOT_LLM_SEARCH_RESPONSE message type constant
- Add onBotLlmSearchResponse delegate method with default implementation
- Add message handling in RTVIClient for bot-llm-search-response messages

Implements grounding metadata support from PR #1932 in the main Pipecat repository. Aligns naming conventions with JavaScript SDK patterns for consistency across platforms.