### PR TITLE
Added support for lower versions of Xcode (16.2 and below)

### DIFF
--- a/Sources/PipecatClientIOS/PipecatClient.swift
+++ b/Sources/PipecatClientIOS/PipecatClient.swift
@@ -786,7 +786,7 @@ open class PipecatClient {
     public func sendClientRequest(msgType: String, data: Value? = nil) async throws -> ClientMessageData {
         try self.assertReady()
         return try await self.dispatchMessage(
-            message: .clientMessage(msgType: msgType, data: data),
+            message: .clientMessage(msgType: msgType, data: data)
         )
     }
 

--- a/Sources/PipecatClientIOS/transport/RTVIMessageInbound.swift
+++ b/Sources/PipecatClientIOS/transport/RTVIMessageInbound.swift
@@ -113,7 +113,7 @@ public struct RTVIMessageInbound: Codable {
     public static func errorMessage(error: String, fatal: Bool = false) -> RTVIMessageInbound {
         return RTVIMessageInbound(
             type: RTVIMessageInbound.MessageType.ERROR,
-            data: BotError(error: error, fatal: fatal).asString,
+            data: BotError(error: error, fatal: fatal).asString
         )
     }
 }

--- a/Sources/PipecatClientIOS/transport/RTVIMessageOutbound.swift
+++ b/Sources/PipecatClientIOS/transport/RTVIMessageOutbound.swift
@@ -37,7 +37,7 @@ public struct RTVIMessageOutbound: Encodable {
             "version": .string(RTVI_PROTOCOL_VERSION),
             "about": .object([
                 "library": .string(PipecatClient.library),
-                "library_version": .string(PipecatClient.libraryVersion),
+                "library_version": .string(PipecatClient.libraryVersion)
             ]),
         ])
         return RTVIMessageOutbound(
@@ -48,7 +48,7 @@ public struct RTVIMessageOutbound: Encodable {
 
     public static func disconnectBot() -> RTVIMessageOutbound {
         return RTVIMessageOutbound(
-            type: RTVIMessageOutbound.MessageType.DISCONNECT_BOT,
+            type: RTVIMessageOutbound.MessageType.DISCONNECT_BOT
         )
     }
 


### PR DESCRIPTION
[This](https://github.com/pipecat-ai/pipecat-client-ios/pull/25) PR added around 3 weeks back created a new version of the pipecat-client-ios library (`1.0.0`). Our team is on the older version (`0.3.0`) of this library. We tried bumping to the new version only to realize it does not build with Xcode 16.2 which all the developers in our company are on currently. 

The issue is the presence of trailing commas in the last parameter in method calls. This is an error in Xcode version 16.2 and below. Apple has started allowing this syntax in Xcode version 16.3 onwards.

We are planning on moving to Xcode 26 soon so did not want to do the intermediary step of bumping to Xcode 16.3 now as this will require us to update our CI pipelines to support this Xcode version and also need all the developers to start using the new version (And then change again to Xcode 26 very soon).

In this PR, I just removed the method calls which had the trailing commas so this version of the library will work even with lower versions of Xcode.