### PR TITLE
Allowing the transports to transform StartBotResult into TransportConnectionParams when using startBotAndConnect.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,9 @@
+# 1.1.0 — Unreleased
+
+### Added
+
+- Allowing the transports to transform `StartBotResult` into `TransportConnectionParams` when using startBotAndConnect.
+
 # 1.1.0 — 2025-10-14
 
 ### Added

--- a/PipecatClientIOS.podspec
+++ b/PipecatClientIOS.podspec
@@ -1,6 +1,6 @@
 Pod::Spec.new do |s|
   s.name         = 'PipecatClientIOS'
-  s.version      = '1.1.0'
+  s.version      = '1.1.1'
   s.summary      = 'Pipecat iOS client library.'
   s.description  = <<-DESC
                     Pipecat iOS client library that implements the RTVI-AI standard.
@@ -9,7 +9,7 @@ Pod::Spec.new do |s|
   s.documentation_url  = "https://docs.pipecat.ai/client/ios/introduction"
   s.license      = { :type => 'BSD-2', :file => 'LICENSE' }
   s.author             = { "Daily.co" => "help@daily.co" }
-  s.source       = { :git => 'https://github.com/pipecat-ai/pipecat-client-ios.git', :tag => "1.1.0" }
+  s.source       = { :git => 'https://github.com/pipecat-ai/pipecat-client-ios.git', :tag => "1.1.1" }
   s.ios.deployment_target = '13.0'
   s.source_files = 'Sources/**/*.{swift,h,m}'
   s.exclude_files = 'Sources/Exclude'

--- a/README.md
+++ b/README.md
@@ -14,7 +14,7 @@ The base class has no out-of-the-box bindings included.
 To depend on the client package, you can add this package via Xcode's package manager using the URL of this git repository directly, or you can declare your dependency in your `Package.swift`:
 
 ```swift
-.package(url: "https://github.com/pipecat-ai/pipecat-client-ios.git", from: "1.1.0"),
+.package(url: "https://github.com/pipecat-ai/pipecat-client-ios.git", from: "1.1.1"),
 ```
 
 and add `"PipecatClientIOS"` to your application/library target, `dependencies`, e.g. like this:

--- a/Sources/PipecatClientIOS/PipecatClientVersion.swift
+++ b/Sources/PipecatClientIOS/PipecatClientVersion.swift
@@ -3,6 +3,6 @@ import Foundation
 extension PipecatClient {
 
     public static let library = "pipecat-client-ios"
-    public static let libraryVersion = "1.1.0"
+    public static let libraryVersion = "1.1.1"
 
 }

--- a/Sources/PipecatClientIOS/transport/Transport.swift
+++ b/Sources/PipecatClientIOS/transport/Transport.swift
@@ -26,4 +26,6 @@ public protocol Transport {
     func state() -> TransportState
     func setState(state: TransportState)
     func tracks() -> Tracks?
+    func transformStartBotResultToConnectionParams(startBotParams: APIRequest, startBotResult: StartBotResult) throws
+        -> TransportConnectionParams
 }

--- a/Sources/PipecatClientIOS/types/StartBotResult.swift
+++ b/Sources/PipecatClientIOS/types/StartBotResult.swift
@@ -1,0 +1,3 @@
+import Foundation
+
+public protocol StartBotResult: Decodable {}


### PR DESCRIPTION
Allowing the transports to transform StartBotResult into TransportConnectionParams when using startBotAndConnect.