### PR TITLE
Fixed a memory leak in the PipecatClient

### DIFF
--- a/Sources/PipecatClientIOS/PipecatClient.swift
+++ b/Sources/PipecatClientIOS/PipecatClient.swift
@@ -18,7 +18,8 @@ open class PipecatClient {
 
     private var functionCallCallbacks: [String: FunctionCallCallback] = [:]
 
-    private lazy var onMessage: (RTVIMessageInbound) -> Void = { (voiceMessage: RTVIMessageInbound) in
+    private lazy var onMessage: (RTVIMessageInbound) -> Void = { [weak self] (voiceMessage: RTVIMessageInbound) in
+        guard let self else { return }
         guard let type = voiceMessage.type else {
             // Ignoring the message, it doesn't have a type
             return


### PR DESCRIPTION
Problem:
The `onMessage ` closure captures a strong reference to self due to which the PipecatClient/DailyTransport were not getting deallocated even after the session was over. 

<img width="512" height="512" alt="Screenshot 2025-12-03 at 9 51 21 AM" src="https://github.com/user-attachments/assets/4b9eaeb7-cab2-4396-85a7-d3ea937b1e77" />

Fix: 
Changed to a weak self.